### PR TITLE
fix: correct sphinx docs base url in github pages

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -44,6 +44,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
           BRANCH: gh-pages
-          FOLDER: build
+          FOLDER: build/html
           CLEAN: true
 


### PR DESCRIPTION
the document path is `build/html`